### PR TITLE
Fix null comparison bug

### DIFF
--- a/SDK.CSharp/Updatables/AsyncUpdatableVariable.cs
+++ b/SDK.CSharp/Updatables/AsyncUpdatableVariable.cs
@@ -1,4 +1,5 @@
-﻿using OpenShock.MinimalEvents;
+using System.Collections.Generic;
+using OpenShock.MinimalEvents;
 
 namespace OpenShock.SDK.CSharp.Updatables;
 
@@ -9,7 +10,7 @@ public sealed class AsyncUpdatableVariable<T>(T internalValue) : IAsyncUpdatable
         get => _internalValue;
         set
         {
-            if (_internalValue!.Equals(value)) return;
+            if (EqualityComparer<T>.Default.Equals(_internalValue, value)) return;
             _internalValue = value;
             Task.Run(() => _updated.InvokeAsyncParallel(value));
         }


### PR DESCRIPTION
## Summary
- prevent potential `NullReferenceException` in `AsyncUpdatableVariable`

## Testing
- `dotnet test SDK.CSharp.slnx` *(fails: compatible .NET SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b496310648327998f1803932adc5c